### PR TITLE
Refactoring_enigma_2

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -6,7 +6,6 @@ class Enigma < ShiftGenerator
 
   def initialize
     @character_set = ("a".."z").to_a << " "
-    @shifts = {}
     @encrypted = []
     @decrypted = []
   end
@@ -17,11 +16,10 @@ class Enigma < ShiftGenerator
   end
 
   def random_number
-    number = rand(99999).to_s
-    "%05d" % number
+    number = rand(99999)
   end
 
-  def encrypt(string, key = random_number, date = todays_date)
+  def encrypt(string, key = "%05d" % random_number.to_s, date = todays_date)
     string = string.downcase
     generate_shifts(key, date)
     index_hash = sort_char_shift_by_index(string)
@@ -56,7 +54,7 @@ class Enigma < ShiftGenerator
     end
   end
 
-  def decrypt(string, keys, offsets)
+  def decrypt(string, keys, offsets = todays_date)
     generate_shifts(keys, offsets)
     index_hash = sort_char_shift_by_index(string)
     string.chars.each_with_index do |char, index|

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -38,9 +38,8 @@ class EnigmaTest < MiniTest::Test
 
   def test_it_has_todays_date
 
-    enigma = mock
-    enigma.expects(:todays_date).returns("081819")
-    assert_equal "081819", enigma.todays_date
+    todays_date = Date.today.strftime("%m%d%y")
+    assert_equal todays_date, @enigma.todays_date
   end
 
   def test_it_can_encrypt_a_message_using_todays_date
@@ -53,17 +52,14 @@ class EnigmaTest < MiniTest::Test
 
   def test_it_can_decrypt_a_message_using_todays_date
 
-    expected = {:decryption=>"edhplzssok ", :key=>"02715", :date=>"050119"}
-    enigma = mock
-    enigma.stubs(:decrypt).returns(expected)
-    assert_equal expected, enigma.decrypt("keder ohulw", "02715")
+    expected = {:decryption=>"fdhpmzsspk ", :key=>"02715", :date=>"010619"}
+    assert_equal expected, @enigma.decrypt("keder ohulw", "02715")
   end
 
   def test_it_has_a_random_number
 
-    enigma = mock
-    enigma.expects(:random_number).returns("62743")
-    assert_equal "62743", enigma.random_number
+    num = @enigma.random_number
+    assert_equal num.between?(0,99999), true
   end
 
 


### PR DESCRIPTION
- Changed tests random_number and todays_date to stop using mocks and stubs
- Test coverage - 100%
- Deleted shift instance variable in enigma because its inheriting from ShiftGenerator already